### PR TITLE
Adiciona Python Sudeste 2019

### DIFF
--- a/conferencias.yaml
+++ b/conferencias.yaml
@@ -153,3 +153,9 @@
   end: 2018-12-15
   location: Porto Alegre, RS
   url: https://www.meetup.com/pt-BR/PyData-Porto-Alegre/
+  
+- name: Python Sudeste 2019
+  start: 2019-4-26
+  end: 2006-4-28
+  location: Vitória, ES
+  url: http://2019.pythonsudeste.org/


### PR DESCRIPTION
Evento Python Sudeste que irá acontecer no ES, entre os dias 26 e 28 de abril de 2019.