### PR TITLE
Corrigindo exibição da data

### DIFF
--- a/pythonnobrasil/cal.py
+++ b/pythonnobrasil/cal.py
@@ -40,7 +40,7 @@ class Event:
 
     @property
     def display_date(self):
-        return self.start.strftime("%b %m")
+        return self.start.strftime("%b %d")
 
 
 class Calendar:


### PR DESCRIPTION
Mostrava: abreviação do mês + número do mês
O que deveria mostrar: abreviação do mês + dia